### PR TITLE
prep for release 2.1b

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,6 @@ Contributors to this project include:
 Evguenia Kopylova (jenya.kopylov@gmail.com)
 Laurent Noé (laurent.noe@lifl.fr)
 Pierre Pericard (pierre.pericard@lifl.fr)
-Daniel McDonald (Daniel.McDonald@systemsbiology.org)
+Daniel McDonald (daniel.mcdonald@colorado.edu )
 Rob Knight (robknight@ucsd.edu)
 Hélène Touzet (helene.touzet@lifl.fr)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,8 @@
+Contributors to this project include:
+
 Evguenia Kopylova (jenya.kopylov@gmail.com)
 Laurent Noé (laurent.noe@lifl.fr)
+Pierre Pericard (pierre.pericard@lifl.fr)
+Daniel McDonald (Daniel.McDonald@systemsbiology.org)
+Rob Knight (robknight@ucsd.edu)
 Hélène Touzet (helene.touzet@lifl.fr)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+03 March 2016 [Release 2.1b]
+----------------------------
+	- fix issue regarding duplications in include_HEADERS for Galaxy (see pull request 105)
+
 01 February 2016 [Release 2.1]
 -----------------------------
 31 August 2015

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.50])
-AC_INIT([sortmerna],[2.1],[jenya DT kopylov AT gmail DT fr],[sortmerna],[http://bioinfo.lifl.fr/sortmerna])
+AC_INIT([sortmerna],[2.1b],[jenya DT kopylov AT gmail DT fr],[sortmerna],[http://bioinfo.lifl.fr/sortmerna])
 AC_CONFIG_SRCDIR([src/main.cpp])
 AC_CONFIG_HEADERS([include/config.h])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/src/indexdb.cpp
+++ b/src/indexdb.cpp
@@ -112,7 +112,7 @@ uint32_t num_elem[100] = {0};
 bool verbose = false;
 
 // change version number here
-char version_num[] = "2.1, 01/02/2016";
+char version_num[] = "2.1b, 03/03/2016";
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@ int32_t seed_hits_gv = -1;
 int32_t edges_gv = -1;
 bool full_search_gv = false;
 /*! @brief Version number */
-char version_num[] = "2.1, 01/02/2016";
+char version_num[] = "2.1b, 03/03/2016";
 bool as_percent_gv = false;
 bool pid_gv = false;
 int32_t num_best_hits_gv = 0;


### PR DESCRIPTION
update release version and authors for release 2.1b which includes a fix to issue regarding duplications in include_HEADERS for Galaxy (see merged pull request [105](https://github.com/biocore/sortmerna/pull/105#issuecomment-190608106))