### PR TITLE
Updated conda channel config order

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ SortMeRNA 4 can be run/built on Linux, and Windows (Mac coming soon).
 ## Using Conda package
 
 ```
+conda config --add channels defaults
 conda config --add channels bioconda
+conda config --add channels conda-forge
 
 conda search sortmerna
   Loading channels: done


### PR DESCRIPTION
According to bioconda documentation (https://bioconda.github.io/user/install.html#install-conda), the channels need to be configured in that specific order for bioconda tools to work correctly.